### PR TITLE
Add method .make_twin() for twin-branded containers

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -421,6 +421,27 @@ impl<'id, Array, T> Container<'id, Array, OnlyIndex>
     }
 }
 
+impl<'id, Array, T, Mode> Container<'id, Array, Mode>
+    where Array: Trustworthy<Item=T>
+{
+    /// Create a twin Container, that admits the same branded indices as self
+    ///
+    /// Checks the compatibilty (length) of both arrays and returns the
+    /// twin container if it is admissible.
+    ///
+    /// The twin container is OnlyIndex-marked, because only indices/index
+    /// ranges transfer between twins, and branded raw pointers of course not.
+    pub fn make_twin<Array2>(&self, arr: Array2) -> Result<Container<'id, Array2, OnlyIndex>, IndexingError>
+        where Array2: Trustworthy
+    {
+        if self.len() != arr.base_len() {
+            Err(index_error())
+        } else {
+            Ok(Container { id: self.id, arr: arr, mode: PhantomData })
+        }
+    }
+}
+
 /// `&self[i]` where `i` is an `Index<'id>`.
 impl<'id, Array, M> ops::Index<Index<'id>> for Container<'id, Array, M>
     where Array: GetUnchecked

--- a/tests/compile-fail/multiborrow.rs
+++ b/tests/compile-fail/multiborrow.rs
@@ -9,11 +9,12 @@ fn main() {
         let (a, b) = arr1.range().split_in_half();
         for i in a {
             for j in b {
-                &mut arr1[i];
-                &mut arr1[j];
+                let _ = &mut arr1[i];
+                let _ = &mut arr1[j];
 
-                let _x = &arr1[i];
-                let _y = &mut arr1[j]; //~ ERROR: as mutable because it is also borrowed
+                let xi2 = &arr1[i];
+                let yi2 = &mut arr1[j]; //~ ERROR: as mutable because it is also borrowed
+                *yi2 = *xi2;
             }
         }
     });

--- a/tests/compile-fail/twin-pointers.rs
+++ b/tests/compile-fail/twin-pointers.rs
@@ -1,0 +1,22 @@
+extern crate indexing;
+
+use indexing::scope;
+
+fn main() {
+    let mut arr1 = [1, 2, 3, 4, 5i64];
+    let mut arr2 = [6, 7, 8, 9, 0];
+
+    // can hold onto the pointers for later, as long they stay in the closure
+    let _a = scope(&mut arr1[..], |arr| {
+        let r = arr.pointer_range();
+        let r = r.nonempty().unwrap();      
+        let i = r.first();
+        let (a, b) = arr.split_at_pointer(i);
+
+        let twin = arr.make_twin(&mut arr2[..]).unwrap();
+        let elt = twin[i]; //~ ERROR: cannot be indexed by
+        twin.split_at_pointer(i); //~ ERROR: no method named
+    });
+}
+
+

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -13,6 +13,8 @@ fn run_mode(mode: &'static str) {
     config.mode = cfg_mode;
     config.src_base = PathBuf::from(format!("tests/{}", mode));
     config.target_rustcflags = Some("-L target/debug".to_string());
+    config.link_deps();
+    //config.clean_rmeta();
 
     compiletest::run_tests(&config);
 }


### PR DESCRIPTION
This allows you to have several equivalent containers that allow the
same indices and ranges.

As demonstration, see the insertion_sort2 implementation that sorts two
arrays in lock step with each other.