### PR TITLE
Fix bug in .join_cover() and bug in ContiguousMut

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -87,3 +87,31 @@ impl<'id, T, P> Provable for PSlice<'id, T, P> {
     }
 }
 
+#[cfg(test)]
+pub(crate) trait ProofType {
+    fn nonempty() -> bool;
+    fn unknown() -> bool { !Self::nonempty() }
+}
+
+#[cfg(test)]
+impl ProofType for Unknown {
+    fn nonempty() -> bool { false }
+}
+
+#[cfg(test)]
+impl ProofType for NonEmpty {
+    fn nonempty() -> bool { false }
+}
+
+
+#[cfg(test)]
+impl<'id, P> Index<'id, P> {
+    pub(crate) fn nonempty_proof(&self) -> bool where P: ProofType
+    { P::nonempty() }
+}
+
+#[cfg(test)]
+impl<'id, P> Range<'id, P> {
+    pub(crate) fn nonempty_proof(&self) -> bool where P: ProofType
+    { P::nonempty() }
+}


### PR DESCRIPTION
.join_cover() changes so that it reuses the proof of the first parameter; this is an API break but the proof was wrong, so it's only good.

Fix ContiguousMut methods to use a `&mut` receiver for the mutable raw pointer methods. This is an API brak, but the old signature was alway wrong.

Fixes #11 
Fixes #12 