### PR TITLE
Use Rust 2018 and try to fix compiletest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ script:
       cargo build -v --no-default-features &&
       cargo test -v --no-default-features &&
       cargo build -v --features=$FEATURES &&
+      if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+        cargo clean
+      fi &&
       cargo test -v --features=$FEATURES &&
       if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
         cargo bench -v --no-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.27.0
+    - rust: 1.32.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+  allow_failures:
+    - rust: nightly
       env:
         FEATURES='test_compiletest'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+    - rust: nightly
+      env: FEATURES='test_compiletest'
   allow_failures:
     - rust: nightly
-      env:
-        FEATURES='test_compiletest'
+      env: FEATURES='test_compiletest'
 env:
   global:
     - HOST=x86_64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "indexing"
 version = "0.3.2"
 authors = ["bluss"]
+edition = "2018"
 
 license = "MIT/Apache-2.0"
 repository = "https://github.com/bluss/indexing"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,7 +7,7 @@ extern crate indexing;
 
 
 use test::Bencher;
-use test::black_box;
+
 
 
 

--- a/benches/merge.rs
+++ b/benches/merge.rs
@@ -15,7 +15,7 @@ macro_rules! bench_insertion_sort {
         $(
         mod $name {
             use indexing::algorithms::*;
-            use bench_data;
+            use crate::bench_data;
             use test::Bencher;
             use std::mem;
             #[bench]

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -383,7 +383,7 @@ pub fn merge_internal_indices<T: Ord>(data: &mut [T], left_end: usize, buffer: &
 {
     debug_assert!(data.len() >= 1);
     if left_end > data.len() || left_end > buffer.len() {
-        r#try!(Err("merge_internal: data or buffer too short"));
+        Err("merge_internal: data or buffer too short")?;
     }
     scope(data, move |mut data| {
         let r = data.range();
@@ -440,7 +440,7 @@ pub fn merge_internal_ranges<T: Ord>(data: &mut [T], left_end: usize, buffer: &m
 {
     debug_assert!(data.len() >= 1);
     if left_end > data.len() || left_end > buffer.len() {
-        r#try!(Err("merge_internal: data or buffer too short"));
+        Err("merge_internal: data or buffer too short")?;
     }
     scope(data, |mut data| {
         let r = data.range();

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -7,8 +7,8 @@
 use std::cmp::{self, Ordering};
 use std::mem::swap;
 
-use scope;
-use pointer::zip;
+use crate::scope;
+use crate::pointer::zip;
 
 
 // for debugging -- like println during debugging
@@ -383,7 +383,7 @@ pub fn merge_internal_indices<T: Ord>(data: &mut [T], left_end: usize, buffer: &
 {
     debug_assert!(data.len() >= 1);
     if left_end > data.len() || left_end > buffer.len() {
-        try!(Err("merge_internal: data or buffer too short"));
+        r#try!(Err("merge_internal: data or buffer too short"));
     }
     scope(data, move |mut data| {
         let r = data.range();
@@ -440,7 +440,7 @@ pub fn merge_internal_ranges<T: Ord>(data: &mut [T], left_end: usize, buffer: &m
 {
     debug_assert!(data.len() >= 1);
     if left_end > data.len() || left_end > buffer.len() {
-        try!(Err("merge_internal: data or buffer too short"));
+        r#try!(Err("merge_internal: data or buffer too short"));
     }
     scope(data, |mut data| {
         let r = data.range();
@@ -734,11 +734,11 @@ pub fn lower_bound_prange<T: PartialOrd>(v: &[T], elt: &T) -> usize {
 }
 
 
-use Container;
-use container_traits::Contiguous;
-use pointer::{PIndex, PRange, PSlice};
-use Unknown;
-use proof::Provable;
+use crate::Container;
+use crate::container_traits::Contiguous;
+use crate::pointer::{PIndex, PRange, PSlice};
+use crate::Unknown;
+use crate::proof::Provable;
 
 pub fn lower_bound_prange_<'id, T, P, Array, F>(range: PRange<'id, T, P>,
                                                 v: &Container<'id, Array>,

--- a/src/container.rs
+++ b/src/container.rs
@@ -8,15 +8,15 @@ use std::fmt::{self, Debug};
 
 use std::marker::PhantomData;
 
-use index_error::IndexingError;
-use index_error::index_error;
-use proof::*;
+use crate::index_error::IndexingError;
+use crate::index_error::index_error;
+use crate::proof::*;
 use std;
 
-use container_traits::*;
-use indexing::{IntoCheckedRange};
-use {Id, Index, Range};
-use ContainerPrivate;
+use crate::container_traits::*;
+use crate::indexing::{IntoCheckedRange};
+use crate::{Id, Index, Range};
+use crate::ContainerPrivate;
 
 /// A branded container, that allows access only to indices and ranges with
 /// the exact same brand in the `'id` parameter.

--- a/src/container.rs
+++ b/src/container.rs
@@ -422,7 +422,7 @@ impl<'id, Array, T> Container<'id, Array, OnlyIndex>
 }
 
 impl<'id, Array, T, Mode> Container<'id, Array, Mode>
-    where Array: Trustworthy<Item=T>
+    where Array: Trustworthy<Item=T> + FixedLength
 {
     /// Create a twin Container, that admits the same branded indices as self
     ///
@@ -432,7 +432,7 @@ impl<'id, Array, T, Mode> Container<'id, Array, Mode>
     /// The twin container is OnlyIndex-marked, because only indices/index
     /// ranges transfer between twins, and branded raw pointers of course not.
     pub fn make_twin<Array2>(&self, arr: Array2) -> Result<Container<'id, Array2, OnlyIndex>, IndexingError>
-        where Array2: Trustworthy
+        where Array2: Trustworthy + FixedLength
     {
         if self.len() != arr.base_len() {
             Err(index_error())

--- a/src/container_traits.rs
+++ b/src/container_traits.rs
@@ -27,6 +27,9 @@ pub unsafe trait ContiguousMut : Contiguous {
     fn as_mut_slice(&mut self) -> &mut [Self::Item];
 }
 
+/// The container does not change is length while we are trusting it
+pub unsafe trait FixedLength : Trustworthy { }
+
 unsafe impl<'a, C: ?Sized> Trustworthy for &'a C
     where C: Trustworthy
 {
@@ -151,6 +154,18 @@ unsafe impl<T> Contiguous for [T] {
         self
     }
 }
+
+unsafe impl<'a, C: ?Sized> FixedLength for &'a C
+    where C: FixedLength
+{ }
+
+unsafe impl<'a, C: ?Sized> FixedLength for &'a mut C
+    where C: FixedLength
+{ }
+
+// The slice stays the same length while it's in a container
+// (in contrast, the Vec does not)
+unsafe impl<T> FixedLength for [T] { }
 
 #[cfg(feature = "use_std")]
 mod vec_impls {

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -8,12 +8,12 @@ use std::mem;
 
 use std::fmt::{self, Debug};
 
-use index_error::IndexingError;
-use index_error::index_error;
+use crate::index_error::IndexingError;
+use crate::index_error::index_error;
 use std;
-use proof::*;
+use crate::proof::*;
 
-use {Id, Index, Range};
+use crate::{Id, Index, Range};
 
 
 
@@ -588,7 +588,7 @@ fn test_frac_step() {
 
 #[test]
 fn test_join_cover() {
-    use scope;
+    use crate::scope;
 
     // Bug from https://github.com/bluss/indexing/issues/12
     let array = [0, 1, 2, 3, 4, 5];

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -180,8 +180,9 @@ impl<'id, P> Range<'id, P> {
     /// Extend the range to the end of `other`, including any space in between
     ///
     ///
-    /// ```compile-fail
-    /// // compile-fail only enabled in 2018 edition
+    /// The following example exists only to check that it fails to compile:
+    ///
+    /// ```compile_fail
     /// // Bug from https://github.com/bluss/indexing/issues/12
     /// use indexing::scope;
     ///
@@ -193,7 +194,7 @@ impl<'id, P> Range<'id, P> {
 
     ///     let joined = right.join_cover(left);
     ///     let ix = joined.first();
-    ///     dbg!(arr[ix]);  //~ ERROR Can't index by ix, because it's an edge index
+    ///     arr[ix];  //~ ERROR: Can't index by ix, because it's an edge index
     /// });
     /// ```
     // Proof P: Extends at least as far as self, not necessarily using any part

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,11 +107,11 @@ pub mod pointer;
 mod index_error;
 mod pointer_ext;
 
-pub use index_error::IndexingError;
+pub use crate::index_error::IndexingError;
 
-pub use container::{Container, scope};
+pub use crate::container::{Container, scope};
 
-pub use proof::{NonEmpty, Unknown};
+pub use crate::proof::{NonEmpty, Unknown};
 
 
 // Common types //

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -18,17 +18,17 @@ use std::ptr;
 use std::ops;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 
-use scope;
+use crate::scope;
 use super::Id;
 use super::{NonEmpty, Container};
-use {Unknown};
-use IndexingError;
-use index_error::index_error;
+use crate::{Unknown};
+use crate::IndexingError;
+use crate::index_error::index_error;
 
-use pointer_ext::PointerExt;
-use proof::Provable;
-use container_traits::*;
-use ContainerPrivate;
+use crate::pointer_ext::PointerExt;
+use crate::proof::Provable;
+use crate::container_traits::*;
+use crate::ContainerPrivate;
 
 /// `PIndex` is a pointer to a location.
 ///

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,8 +1,8 @@
 
 use std::mem;
 
-use {Index, Range};
-use pointer::{PIndex, PRange, PSlice};
+use crate::{Index, Range};
+use crate::pointer::{PIndex, PRange, PSlice};
 
 /// Length marker for range known to not be empty.
 #[derive(Copy, Clone, Debug)]

--- a/tests/compile-fail/join_cover.rs
+++ b/tests/compile-fail/join_cover.rs
@@ -1,0 +1,21 @@
+extern crate indexing;
+
+use indexing::scope;
+
+fn main() {
+    // Bug from https://github.com/bluss/indexing/issues/12
+    let array = [0, 1, 2, 3, 4, 5];
+    let ix = scope(&array[..], |arr| {
+        let left = arr.vet_range(0..2).unwrap();
+        let left = left.nonempty().unwrap();
+        let (_, right) = arr.range().frontiers();
+
+        let joined = right.join_cover(left);
+        let ix = joined.first();
+        arr[ix]; //~ ERROR: cannot be indexed by
+        ix.integer()
+    });
+    dbg!(array[ix]);
+}
+
+

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -14,7 +14,7 @@ fn run_mode(mode: &'static str) {
     config.src_base = PathBuf::from(format!("tests/{}", mode));
     config.target_rustcflags = Some("-L target/debug".to_string());
     config.link_deps();
-    //config.clean_rmeta();
+    config.clean_rmeta();
 
     compiletest::run_tests(&config);
 }


### PR DESCRIPTION
- Rust 2018
- Compiletest might work consistently if we have a cargo clean in there
- But if it fails, we allow failures of it in travis, because it's just infuriatingly unpredictable about when it fails